### PR TITLE
3 improvements:

### DIFF
--- a/sourcemapped-stacktrace.js
+++ b/sourcemapped-stacktrace.js
@@ -58,7 +58,7 @@ function(source_map_consumer) {
       if (fields && fields.length === expected_fields) {
         rows[i] = fields;
         uri = fields[1];
-        if (!uri.match(/anonymous/)) {
+        if (!uri.match(/<anonymous>/)) {
           fetcher.fetchScript(uri);
         }
       }
@@ -109,7 +109,7 @@ function(source_map_consumer) {
       //
       // attempt to find it at the very end of the file, but tolerate trailing
       // whitespace inserted by some packers.
-      var match = e.target.responseText.match("//# +sourceMappingURL=(.*)[\\s]*$", "m");
+      var match = e.target.responseText.match("//# [s]ourceMappingURL=(.*)[\\s]*$", "m");
       if (match && match.length === 2) {
         // get the map
         var mapUri = match[1];

--- a/sourcemapped-stacktrace.js
+++ b/sourcemapped-stacktrace.js
@@ -58,7 +58,9 @@ function(source_map_consumer) {
       if (fields && fields.length === expected_fields) {
         rows[i] = fields;
         uri = fields[1];
-        fetcher.fetchScript(uri);
+        if (!uri.match(/anonymous/)) {
+          fetcher.fetchScript(uri);
+        }
       }
     }
   };
@@ -107,7 +109,7 @@ function(source_map_consumer) {
       //
       // attempt to find it at the very end of the file, but tolerate trailing
       // whitespace inserted by some packers.
-      var match = e.target.responseText.match("//# sourceMappingURL=(.*)[\\s]*$", "m");
+      var match = e.target.responseText.match("//# +sourceMappingURL=(.*)[\\s]*$", "m");
       if (match && match.length === 2) {
         // get the map
         var mapUri = match[1];
@@ -180,7 +182,7 @@ function(source_map_consumer) {
           var origPos = smc.originalPositionFor(
             { line: line, column: column });
           result.push(formatOriginalPosition(origPos.source,
-            origPos.line, origPos.column, origPos.name));
+            origPos.line, origPos.column, origPos.name || String(row[0]).replace(/ +at +([^ ]*).*/, '$1')));
         } else {
           // we can't find a map for that url, but we parsed the row.
           // reformat unchanged line for consistency with the sourcemapped


### PR DESCRIPTION
 1. When processing a bundle that contains this source, the search for sourceMappingURL=
    can get a hit on this source itself, causing the source maps to fail to load.  Add a whitespace
    checker to the match expression to avoid this case.
 2. Avoid checking against <anonymous> fns, as these are not ever mapped in source and
    cause an HTTP 404
 3. In the case where the sourcemap library loses the name of the function, supply it back
    with a brute force expression.