### PR TITLE
Proper Node Dependency Resolver for Flattened Tree

### DIFF
--- a/sourcemapped-stacktrace.js
+++ b/sourcemapped-stacktrace.js
@@ -12,7 +12,7 @@
 
 // note we only include source-map-consumer, not the whole source-map library,
 // which includes gear for generating source maps that we don't need
-define(['./node_modules/source-map/lib/source-map-consumer'],
+define(['source-map/lib/source-map-consumer'],
 function(source_map_consumer) {
   /**
    * Re-map entries in a stacktrace using sourcemaps if available.


### PR DESCRIPTION
When NPM or Yarn build a dependency list, they flatten the tree and could move the `source-map` dependency upward (and out of the directory where this package lives). This means the path will not always be `./node_modules`.

Node automatically searches parent directory `./node_modules` paths until it finds the module requested (see https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders)