### PR TITLE
Include stack trace lines only referencing filename

### DIFF
--- a/sourcemapped-stacktrace.js
+++ b/sourcemapped-stacktrace.js
@@ -44,7 +44,7 @@ function(source_map_consumer) {
     var fetcher = new Fetcher(opts);
 
     if (isChromeOrEdge() || isIE11Plus()) {
-      regex = /^ +at.+\((.*):([0-9]+):([0-9]+)/;
+      regex = /^ +at.*[ ]\(?(.*):([0-9]+):([0-9]+)/;
       expected_fields = 4;
       // (skip first line containing exception message)
       skip_lines = 1;

--- a/sourcemapped-stacktrace.js
+++ b/sourcemapped-stacktrace.js
@@ -216,7 +216,7 @@ function(source_map_consumer) {
           var origPos = map.originalPositionFor(
             { line: line, column: column });
           result.push(formatOriginalPosition(origPos.source,
-            origPos.line, origPos.column, origPos.name || origName(lines[i])));
+            origPos.line, origPos.column, origPos.name));
         } else {
           // we can't find a map for that url, but we parsed the row.
           // reformat unchanged line for consistency with the sourcemapped
@@ -241,8 +241,12 @@ function(source_map_consumer) {
 
   var formatOriginalPosition = function(source, line, column, name) {
     // mimic chrome's format
-    return "    at " + (name ? name : "(unknown)") +
-      " (" + source + ":" + line + ":" + column + ")";
+    if (name) {
+      return "    at " + name +
+        " (" + source + ":" + line + ":" + column + ")";
+    }
+
+    return "    at " + source + ":" + line + ":" + column;
   };
 
   // xmlhttprequest boilerplate


### PR DESCRIPTION
Chrome sometimes outputs stack trace lines without function name and paranthesis.

Example:
```
    at logger.js:53
    at new Promise (<anonymous>)
    at buildStackTrace (logger.js:52)
```

This regex allows both types of stack trace output