### PR TITLE
handle optional parentheses in chrome's regex

### DIFF
--- a/sourcemapped-stacktrace.js
+++ b/sourcemapped-stacktrace.js
@@ -61,7 +61,7 @@ function(source_map_consumer) {
     }
 
     if (traceFormat === "chrome") {
-      regex = /^ +at.+\((.*):([0-9]+):([0-9]+)/;
+      regex = /^ +at.* +\(?(.*):([0-9]+):([0-9]+)/;
       expected_fields = 4;
       // (skip first line containing exception message)
       skip_lines = 1;
@@ -249,7 +249,7 @@ function(source_map_consumer) {
   };
 
   function origNameChrome(origLine) {
-    var match = / +at +([^ ]*).*/.exec(origLine);
+    var match = / +at +([^ ]*) +.*/.exec(origLine);
     return match && match[1];
   }
 


### PR DESCRIPTION
This pull request fixes the bug identified here #45 
The regex for chrome works whether the line in the stack trace has parentheses around the file URL or not. Instead of relying on the parentheses, the regex now expects there to be a space in between " at " and the file URL. This should be a more robust approach to match the stack trace.

Examples used for testing
```
    at http://localhost:8080/main.26e4650d3cdd95bc281a.js:87876:62
```
is mapped to
```
    at (unknown) (webpack://project/src/main/webapp/test.js:20:3)
```

Previous mapping continues to work, such as
```
    at Object.error (http://localhost:8080/main.26e4650d3cdd95bc281a.js:87864:76)
```
is mapped to
```
    at Object.error (webpack://project/src/main/webapp/test.js:51:17)
```